### PR TITLE
DAISY-9079: Change publish workflow to require release PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/.github/ @realtimeMD/frontend-owners
+/* @realtimeMD/frontend-owners
+/packages/react-time-picker/* @realtimeMD/frontend-owners

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,109 @@
+name: Prepare Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      semverStrategy:
+        description: 'Select semantic version'
+        type: choice
+        required: true
+        default: patch
+        options:
+          - major
+          - minor
+          - patch
+
+env:
+  HUSKY: 0
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release-pr
+  cancel-in-progress: false
+
+jobs:
+  bump_and_open_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23.10.0
+
+      - name: Enable Corepack (Yarn)
+        run: corepack enable
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+      - name: Bump package version
+        run: |
+          yarn workspace @realtimemd/react-time-picker version "${{ github.event.inputs.semverStrategy }}"
+
+      - name: Read new version
+        id: version
+        run: |
+          echo "version=$(node -p \"require('./packages/react-time-picker/package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Create release branch, commit, and tag
+        id: commit_and_tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          BRANCH="release/react-time-picker-v$VERSION"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          git switch -c "$BRANCH"
+          git add packages/react-time-picker/package.json
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(release): v$VERSION"
+          else
+            echo "No changes to commit. Aborting." >&2
+            exit 1
+          fi
+
+          # Create tag if it doesn't already exist (locally or remotely)
+          TAG="v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists locally; skipping tag creation."
+          else
+            git tag -a "$TAG" -m "react-time-picker v$VERSION"
+          fi
+
+          # Push branch and tag if not present remotely
+          git push origin "$BRANCH"
+          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "Remote tag $TAG already exists; skipping tag push."
+          else
+            git push origin "$TAG"
+          fi
+
+      - name: Open Pull Request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.commit_and_tag.outputs.branch }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          STRATEGY: ${{ github.event.inputs.semverStrategy }}
+        run: |
+          # Avoid creating a duplicate PR
+          if [ -n "$(gh pr list --head "$BRANCH" --json number --jq 'length')" ] && \
+             [ "$(gh pr list --head "$BRANCH" --json number --jq 'length')" != "0" ]; then
+            echo "PR for $BRANCH already exists. Skipping create."
+            exit 0
+          fi
+          gh pr create \
+            --title "Release [$STRATEGY]: @realtimemd/react-time-picker v$VERSION" \
+            --body "This PR bumps @realtimemd/react-time-picker to v$VERSION." \
+            --base "$BASE_BRANCH" \
+            --head "$BRANCH"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,83 +1,128 @@
-name: Release and Publish @realtimemd/react-time-picker
+name: Release and Publish
 
 on:
+  pull_request:
+    types: [closed]
   workflow_dispatch:
     inputs:
-      semverStrategy:
-        description: 'Select semantic version bump strategy'
+      note:
+        description: "This workflow runs automatically when a release PR is merged. Only run it manually if it failed on the last run."
         type: choice
-        required: true
-        default: patch
         options:
-          - major
-          - minor
-          - patch
+          - Understood
+        default: Understood
+        required: false
 
 env:
   HUSKY: 0
 
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-and-publish
+  cancel-in-progress: false
+
 jobs:
-  publish:
+  check_rerun_allowed:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      can_rerun: ${{ steps.check.outputs.can_rerun }}
+      last_conclusion: ${{ steps.check.outputs.last_conclusion }}
+    steps:
+      - name: Check last run status
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const runs = await github.rest.actions.listWorkflowRunsForRepo({
+              owner,
+              repo,
+              per_page: 30,
+              status: 'completed',
+            });
+            const thisRunId = context.runId;
+            const sameWorkflow = runs.data.workflow_runs.filter(r => r.name === context.workflow && r.id !== thisRunId);
+            const last = sameWorkflow[0];
+            const can = !last || last.conclusion !== 'success';
+            core.setOutput('can_rerun', String(can));
+            core.setOutput('last_conclusion', last ? last.conclusion : 'none');
+
+  release_and_publish:
+    needs: [check_rerun_allowed]
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/react-time-picker-v')) ||
+      (github.event_name == 'workflow_dispatch' && needs.check_rerun_allowed.outputs.can_rerun == 'true')
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
+          fetch-tags: true
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
 
-      - name: Use Node.js
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 23.10.0
           registry-url: https://npm.pkg.github.com/
 
-      - name: Enable Corepack (Yarn 4)
+      - name: Enable Corepack (Yarn)
         run: corepack enable
 
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Bump package version
-        run: yarn workspace @realtimemd/react-time-picker version "${{ github.event.inputs.semverStrategy }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Read bumped version
-        id: read_version
+      - name: Get version
+        id: version
         run: |
-          node -e '
-            const fs = require("fs");
-            const pkg = JSON.parse(fs.readFileSync("packages/react-time-picker/package.json", "utf8"));
-            const v = pkg.version;
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${v}\n`);
-            fs.appendFileSync(process.env.GITHUB_ENV, `NEW_VERSION=${v}\n`);
-            console.log(`Detected version: ${v}`);
-          '
+          echo "version=$(node -p \"require('./packages/react-time-picker/package.json').version\")" >> "$GITHUB_OUTPUT"
 
-      - name: Commit Updated package.json file
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .
-          git commit -m "Update Package.json to ${{ steps.read_version.outputs.version }}"
-          git push
-
-      - name: Publish
-        run: yarn npm publish
-        working-directory: packages/react-time-picker
+      - name: Ensure tag exists
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          TAG="v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists."
+          else
+            echo "Creating missing tag $TAG."
+            git tag -a "$TAG" -m "react-time-picker v$VERSION"
+            git push origin "$TAG"
+          fi
 
-      - name: Create Release
-        id: create_release
+      - name: Check if release exists
+        id: check_release
+        uses: actions/github-script@v7
+        env:
+          TAG: v${{ steps.version.outputs.version }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            try {
+              await github.rest.repos.getReleaseByTag({ owner, repo, tag: process.env.TAG });
+              core.setOutput('exists', 'true');
+            } catch (e) {
+              core.setOutput('exists', 'false');
+            }
+
+      - name: Create GitHub Release
+        if: steps.check_release.outputs.exists != 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.read_version.outputs.version }}
-          name: Release ${{ steps.read_version.outputs.version }}
+          token: ${{ github.token }}
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
           draft: false
           prerelease: false
           generate_release_notes: true
+
+      - name: Publish to GitHub Packages (set in package.json)
+        working-directory: packages/react-time-picker
+        run: yarn npm publish
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
[DAISY-9079](https://patientiq.atlassian.net/browse/DAISY-9079)

## Description
The last attempt at a publish workflow required a GitHub personal access token (PAT) to be setup in order to get around the requirement that only approved PRs can be merged to the `main` branch. PATs have to be renewed every year, and are tied to a specific user. We want the workflow to be more robust then that, and also prefer a workflow with a release PR that can be reviewed before it's released for added safety. This also adds a requirement that frontend codeowners review any PRs with changes to config files. This includes package.json so that codeowner reviews are required for release PRs.

## Suggested QA testing
N/A - We won't be able to test this again until it's merged to the `main` branch, because the new "Prepare Release PR" workflow doesn't exist there yet. There may have to be followup PRs to fix any issues.